### PR TITLE
incorrect quaternion generated invalid bbox

### DIFF
--- a/pye57/e57.py
+++ b/pye57/e57.py
@@ -193,7 +193,7 @@ class E57:
                 raise ValueError("Unsupported point field: %s" % field)
 
         if rotation is None:
-            rotation = getattr(scan_header, "rotation", np.array([0, 0, 0, 0]))
+            rotation = getattr(scan_header, "rotation", np.array([0, 0, 0, 1]))
 
         if translation is None:
             translation = getattr(scan_header, "translation", np.array([0, 0, 0]))


### PR DESCRIPTION
This caused the file to be invalid and not load in cloud compare.